### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you're using homebrew-cask, this app can be installed via it. Please tap the 
 
 ```
 brew tap codecentric/merge-request-notifier https://github.com/codecentric/merge-request-notifier
-brew cask install merge-request-notifier
+brew install --cask merge-request-notifier
 ```
 It's the easiest way to install and manage this app on macOS.
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524